### PR TITLE
[Issue 20] Add minimum date on payment

### DIFF
--- a/src/screens/member/payment/MembershipPaymentScreen.js
+++ b/src/screens/member/payment/MembershipPaymentScreen.js
@@ -325,6 +325,7 @@ const MembershipPaymentScreen = ({ navigation, route }) => {
             <BirthPicker
               isOpen={isDatePickerOpen}
               date={birthDate}
+              minimumDate={new Date()}
               onConfirm={(selectedDate) => {
                 setIsDatePickerOpen(false);
                 setBirthDate(selectedDate);

--- a/src/screens/member/payment/OptionPaymentScreen.js
+++ b/src/screens/member/payment/OptionPaymentScreen.js
@@ -292,6 +292,7 @@ const OptionPaymentScreen = ({ navigation, route }) => {
               <BirthPicker
                 isOpen={isOptionDatePickerOpen}
                 date={optionDate}
+                minimumDate={new Date()}
                 onConfirm={(selectedDate) => {
                   setIsOptionDatePickerOpen(false);
                   setOptionDate(selectedDate);

--- a/src/screens/member/payment/TicketPaymentScreen.js
+++ b/src/screens/member/payment/TicketPaymentScreen.js
@@ -398,6 +398,7 @@ const TicketPaymentScreen = ({ navigation, route }) => {
               <BirthPicker
                 isOpen={isTicketDatePickerOpen}
                 date={ticketDate}
+                minimumDate={new Date()}
                 onConfirm={(selectedDate) => {
                   setIsTicketDatePickerOpen(false);
                   setTicketDate(selectedDate);


### PR DESCRIPTION
- issue 20 `수강권 구매 시 과거 날짜를 시작일로 수강권을 구매할 수 있는 버그 있음`
- 결제 창에 한해서 현재 날짜부터 날짜를 선택 할 수 있게 수정