### PR TITLE
[issue 32] 

### DIFF
--- a/src/screens/member/payment/MembershipPaymentScreen.js
+++ b/src/screens/member/payment/MembershipPaymentScreen.js
@@ -193,7 +193,11 @@ const MembershipPaymentScreen = ({ navigation, route }) => {
           //   },
           // });
         }
-      } else{
+      } 
+      else if (checkerdata.data.result === 2){
+        Alert.alert("이미 결제 대기중인 회원권이 존재합니다. 관리자에게 문의하세요");
+      }
+      else{
         Alert.alert("이미 회원권이 존재합니다");
       }
     }

--- a/src/screens/member/payment/OptionPaymentScreen.js
+++ b/src/screens/member/payment/OptionPaymentScreen.js
@@ -177,7 +177,10 @@ const OptionPaymentScreen = ({ navigation, route }) => {
             // });
           }
 
-        } else{
+        }
+        else if (checkerdata.data.result === 2){
+          Alert.alert("이미 결제 대기중인 옵션권이 존재합니다. 관리자에게 문의하세요");
+        }else{
           Alert.alert("이미 옵션권이 존재합니다");
         }
     }

--- a/src/screens/member/payment/TicketPaymentScreen.js
+++ b/src/screens/member/payment/TicketPaymentScreen.js
@@ -199,6 +199,8 @@ const TicketPaymentScreen = ({ navigation, route }) => {
           //   },
           // });
         }
+      }else if (checkerdata.data.result === 2){
+        Alert.alert("이미 결제 대기중인 수강권이 존재합니다. 관리자에게 문의하세요");
       }else{
         Alert.alert("이미 수강권이 존재합니다");
       }


### PR DESCRIPTION
- issue 32 `현금 결제 시 기존에 동일 수강권으로 기존에 결제 대기중인 경우 "현금영수증이 필요하신가요?" 라고 알럿 후 반응이 없음`
- 수정된 API를 조회하여 현 결재 상태  확인하는 코드 추가